### PR TITLE
Remove spaces from default identity

### DIFF
--- a/serverless/constants.js
+++ b/serverless/constants.js
@@ -4,5 +4,5 @@ module.exports = {
   SERVICE_NAME: 'rtc-diagnostics',
   API_KEY_NAME: 'RTC Diagnostics Key',
   TWIML_APP_NAME: 'Test TwiML App',
-  VOICE_IDENTITY: process.env.VOICE_IDENTITY || 'RTC Diagnostics Test Identity',
+  VOICE_IDENTITY: process.env.VOICE_IDENTITY || 'RTC_Diagnostics_Test_Identity',
 };


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This PR removes spaces from the default voice identity. It prevents 31105 errors:

`Invalid client name/identity. Note, the client name/identity provided in the AccessToken may only contain alpha-numeric and underscore characters. Other characters, including spaces, will result in undefined behavior. The maximum number of characters for the identity is 121.`

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary