### PR TITLE
Update e2e tests

### DIFF
--- a/serverless/__tests__/e2e/e2e.ts
+++ b/serverless/__tests__/e2e/e2e.ts
@@ -2,6 +2,9 @@ import runDeploy from '../../scripts/deploy';
 import runRemove from '../../scripts/remove';
 import jwt from 'jsonwebtoken';
 import constants from '../../constants';
+import Twilio from 'twilio';
+
+const client = Twilio(process.env.ACCOUNT_SID, process.env.AUTH_TOKEN);
 
 constants.SERVICE_NAME = 'rtc-diagnostics-e2e-test-' + Math.random().toString(36).slice(2);
 
@@ -24,10 +27,9 @@ describe('', () => {
     await runRemove();
     stdout.stop();
 
-    expect(superagent.get(`${appURL}/app/token`)).rejects.toEqual(new Error('Not Found'));
-    expect(superagent.get(`${appURL}/app/turn-credentials`)).rejects.toEqual(new Error('Not Found'));
-    expect(superagent.get(`${appURL}/twiml/play`)).rejects.toEqual(new Error('Not Found'));
-    expect(superagent.get(`${appURL}/twiml/record`)).rejects.toEqual(new Error('Not Found'));
+    const services = await client.serverless.services.list();
+    const app = services.find((service) => service.friendlyName.includes(constants.SERVICE_NAME));
+    expect(app).toBe(undefined);
   });
 
   describe('the token function', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This PR changes our e2e tests so that they don't rely on Functions and Assets being torn down immediately. Instead of asserting that all of the Functions will return a Not found error after the tests are finished, we instead assert that that the Service is correctly removed. We can assume that Twilio will eventually remove all of the Functions and Assets once the Service is removed.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary